### PR TITLE
fix: 修复编码问题导致的注释和输出乱码

### DIFF
--- a/project_0/applications/main.c
+++ b/project_0/applications/main.c
@@ -22,7 +22,7 @@ int main(void)
 
 #include <lcd.h>
 
-/*Camera閲囬泦瀹屾垚鍥炶皟鍑芥暟*/
+/*Camera采集完成回调函数*/
 volatile uint32_t g_dvp_finish_flag;
 rt_err_t camera_cb(rt_device_t dev, size_t size){
     g_dvp_finish_flag = 1;
@@ -33,35 +33,35 @@ int camera_sample(void)
 
 #if 1
    rt_kprintf("Hello, world\n");
-   /* read涓�甯у浘鍍�,鏄剧ず涓嶢I鍥惧儚浼氭寜椤哄簭杩炵画鎺掓斁鍦╞uffer涓� */
+   /* read一帧图像,显示与AI图像会按顺序连续排放在buffer中 */
    uint8_t* display_image = rt_malloc((240 * 320 * 2) + (240 * 320 * 3));
     /* LCD init */
    rt_kprintf("LCD init\n");
    lcd_init();
-   //娓呭睆
+   //清屏
    lcd_clear(BLUE);
    lcd_draw_rectangle(10, 10, 100, 100,1,RED);
-   /* DVP init & 鎽勫儚澶村垵濮嬪寲*/
+   /* DVP init & 摄像头初始化*/
    rt_kprintf("DVP init\n");
-   rt_device_t camera_dev = rt_device_find("gc0308"); //鏌ユ壘鎽勫儚澶磋澶�"gc0308"
+   rt_device_t camera_dev = rt_device_find("gc0308"); //查找摄像头设备"gc0308"
    if(!camera_dev) {
        rt_kprintf("find camera err!\n");
        return -1;
    };
-   rt_device_init(camera_dev); //鍒濆鍖栨憚鍍忓ご
-   rt_device_open(camera_dev,RT_DEVICE_OFLAG_RDWR); //鎵撳紑鎽勫儚澶�,璇诲啓妯″紡
-   rt_device_set_rx_indicate(camera_dev,camera_cb); //璁剧疆read鍥炶皟鍑芥暟
+   rt_device_init(camera_dev); //初始化摄像头
+   rt_device_open(camera_dev,RT_DEVICE_OFLAG_RDWR); //打开摄像头,读写模式
+   rt_device_set_rx_indicate(camera_dev,camera_cb); //设置read回调函数
 
-   /* enable global interrupt ,浣胯兘鍏ㄥ眬涓柇*/
+   /* enable global interrupt ,使能全局中断*/
    sysctl_enable_irq();
    while (1){
            g_dvp_finish_flag = 0;
-           /* 閲囬泦鍥惧儚鏄剧ず&AI鐢眃isplay_image鍦板潃寮�濮嬭繛缁瓨鏀� */
+           /* enable global interrupt ,使能全局中断*/
            rt_device_read(camera_dev,0,display_image,0);
-           while (g_dvp_finish_flag == 0) {};  //绛夊緟
+           while (g_dvp_finish_flag == 0) {};  //等待
            rt_kprintf("dvp cap\n");
-//           __pixel_reversal(display_image, 320, 240);//lcd鍍忕礌浜ら敊
-           //LCD鏄剧ず
+//           __pixel_reversal(display_image, 320, 240);//lcd像素交错
+           //LCD显示
            lcd_draw_picture(0, 0, 320, 240, display_image);
            lcd_draw_rectangle(10, 10, 100, 100,1,RED);
    }

--- a/project_0/driver/drv_io_config.c
+++ b/project_0/driver/drv_io_config.c
@@ -129,14 +129,14 @@ static int print_io_config()
 {
     int i;
     rt_kprintf("IO Configuration Table\n");
-    rt_kprintf("鈹屸攢鈹�鈹�鈹�鈹�鈹�鈹�鈹攢鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹怽n");
-    rt_kprintf("鈹侾in    鈹侳unction                鈹俓n");
-    rt_kprintf("鈹溾攢鈹�鈹�鈹�鈹�鈹�鈹�鈹尖攢鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹n");
+    rt_kprintf("┌───────┬────────────────────────┐\n");
+    rt_kprintf("│Pin    │Function                │\n");
+    rt_kprintf("├───────┼────────────────────────┤\n");
     for(i = 0; i < sizeof io_config / sizeof io_config[0]; i++)
     {
-        rt_kprintf("鈹�%-2d     鈹�%-24.24s鈹俓n", io_config[i].io_num, io_config[i].func_name);
+        rt_kprintf("│%-2d     │%-24.24s│\n", io_config[i].io_num, io_config[i].func_name);
     }
-    rt_kprintf("鈹斺攢鈹�鈹�鈹�鈹�鈹�鈹�鈹粹攢鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹�鈹榎n");
+    rt_kprintf("└───────┴────────────────────────┘\n");
     return 0;
 }
 MSH_CMD_EXPORT_ALIAS(print_io_config, io, print io config);


### PR DESCRIPTION
之前某次提交之后，可能是编码原因，导致了一些字符串出现了乱码。
其中 drv_io_config.c 中的乱码已经严重影响 FinSH 中的 io 指令的正常使用了，因此根据出现乱码之前的原字符串对现在的乱码字符串进行了修改。

修复前：
![before_fix](https://github.com/RT-Thread-Studio/sdk-bsp-draco/assets/65452214/420a7e18-e65b-4cec-9fb3-d632435f23d6)

修复后：
![after_fix](https://github.com/RT-Thread-Studio/sdk-bsp-draco/assets/65452214/57a00062-d1cf-4573-a982-c5a792ed86ed)
